### PR TITLE
bullseye_support

### DIFF
--- a/etc/initramfs-tools/hooks/bond
+++ b/etc/initramfs-tools/hooks/bond
@@ -17,5 +17,4 @@ esac
 
 if grep -q ^BOND= /etc/initramfs-tools/initramfs.conf; then
     manual_add_modules bonding
-    copy_exec /sbin/ifenslave /sbin
 fi

--- a/etc/initramfs-tools/scripts/local-bottom/bond
+++ b/etc/initramfs-tools/scripts/local-bottom/bond
@@ -20,7 +20,10 @@ fi
 for BOND_IFACE in ${BOND:-*}; do
     BOND_DEVICE=$(echo $BOND_IFACE | cut -d":" -f1)
     BOND_SLAVES=$(echo $BOND_IFACE | cut -d":" -f2 | sed "s/,/ /g" )
-    ifenslave -d $BOND_DEVICE $BOND_SLAVES
+    ip link add $BOND_DEVICE type bond
+    for BOND_SLAVE in $BOND_SLAVES; do
+        ip link set $BOND_SLAVE master bond0
+    done
     ip link delete $BOND_DEVICE
 done
 

--- a/etc/initramfs-tools/scripts/local-top/bond
+++ b/etc/initramfs-tools/scripts/local-top/bond
@@ -22,7 +22,9 @@ for BOND_IFACE in ${BOND:-*}; do
     BOND_DEVICE=$(echo $BOND_IFACE | cut -d":" -f1)
     BOND_SLAVES=$(echo $BOND_IFACE | cut -d":" -f2 | sed "s/,/ /g" )
     ip link add $BOND_DEVICE type bond
-    ifenslave $BOND_DEVICE $BOND_SLAVES
+    for BOND_SLAVE in $BOND_SLAVES; do
+        ip link set $BOND_SLAVE master bond0
+    done
 done
 
 exit 0


### PR DESCRIPTION
fix bullseye version, since ifenslave is deprecated (no longer available) due to usage of iproute2