### PR TITLE
Improve config guard and add log messages

### DIFF
--- a/etc/initramfs-tools/scripts/local-bottom/bond
+++ b/etc/initramfs-tools/scripts/local-bottom/bond
@@ -13,8 +13,11 @@ case "$1" in
     ;;
 esac
 
-if grep -q ^BOND= /conf/initramfs.conf; then
-    . /conf/initramfs.conf
+. /scripts/functions
+. /conf/initramfs.conf
+
+if [ -z "$BOND" ]; then
+    exit 0
 fi
 
 for BOND_IFACE in ${BOND:-*}; do
@@ -24,7 +27,9 @@ for BOND_IFACE in ${BOND:-*}; do
     for BOND_SLAVE in $BOND_SLAVES; do
         ip link set $BOND_SLAVE master bond0
     done
+    log_begin_msg "Bringing down $BOND_DEVICE"
     ip link delete $BOND_DEVICE
+    log_end_msg
 done
 
 exit 0

--- a/etc/initramfs-tools/scripts/local-bottom/vlan
+++ b/etc/initramfs-tools/scripts/local-bottom/vlan
@@ -13,12 +13,17 @@ case "$1" in
     ;;
 esac
 
-if grep -q ^VLAN= /conf/initramfs.conf; then
-    . /conf/initramfs.conf
+. /scripts/functions
+. /conf/initramfs.conf
+
+if [ -z "$VLAN" ]; then
+    exit 0
 fi
 
 for VLAN_IFACE in ${VLAN:-*}; do
     SOURCE_IFACE=$(echo $VLAN_IFACE | cut -d":" -f1)
     VLAN_ID=$(echo $VLAN_IFACE | cut -d":" -f2)
+    log_begin_msg "Bringing down $SOURCE_IFACE.$VLAN_ID"
     ip link delete $SOURCE_IFACE.$VLAN_ID
+    log_end_msg
 done

--- a/etc/initramfs-tools/scripts/local-top/bond
+++ b/etc/initramfs-tools/scripts/local-top/bond
@@ -13,18 +13,24 @@ case "$1" in
     ;;
 esac
 
-if grep -q ^BOND= /conf/initramfs.conf; then
-    . /conf/initramfs.conf
-    modprobe bonding $BOND_MODE
+. /scripts/functions
+. /conf/initramfs.conf
+
+if [ -z "$BOND" ]; then
+    exit 0
 fi
+
+modprobe bonding $BOND_MODE
 
 for BOND_IFACE in ${BOND:-*}; do
     BOND_DEVICE=$(echo $BOND_IFACE | cut -d":" -f1)
-    BOND_SLAVES=$(echo $BOND_IFACE | cut -d":" -f2 | sed "s/,/ /g" )
+    BOND_SLAVES=$(echo $BOND_IFACE | cut -d":" -f2 | sed "s/,/ /g")
+    log_begin_msg "Bringing up $BOND_DEVICE"
     ip link add $BOND_DEVICE type bond
     for BOND_SLAVE in $BOND_SLAVES; do
         ip link set $BOND_SLAVE master bond0
     done
+    log_end_msg
 done
 
 exit 0

--- a/etc/initramfs-tools/scripts/local-top/vlan
+++ b/etc/initramfs-tools/scripts/local-top/vlan
@@ -13,17 +13,23 @@ case "$1" in
     ;;
 esac
 
-if grep -q ^VLAN= /conf/initramfs.conf; then
-    . /conf/initramfs.conf
-    modprobe 8021q
+. /scripts/functions
+. /conf/initramfs.conf
+
+if [ -z "$VLAN" ]; then
+    exit 0
 fi
+
+modprobe 8021q
 
 for VLAN_IFACE in ${VLAN:-*}; do
     SOURCE_IFACE=$(echo $VLAN_IFACE | cut -d":" -f1)
     VLAN_ID=$(echo $VLAN_IFACE | cut -d":" -f2)
+    log_begin_msg "Bringing up $SOURCE_IFACE.$VLAN_ID"
     ip link add link $SOURCE_IFACE name $SOURCE_IFACE.$VLAN_ID type vlan id $VLAN_ID
     ip link set $SOURCE_IFACE up
     ip link set $SOURCE_IFACE.$VLAN_ID up
+    log_end_msg
 done
 
 exit 0


### PR DESCRIPTION
The `for`-loop would still run for one iteration, even when `BOND` or `VLAN` is unset, we now exit early instead.

Log messages were also added (but can be removed if that's unwanted).