### PR TITLE
Add configuration for interface hardware address

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Add the following Line to your `/etc/initramfs-tools/initramfs.conf` to enslave 
 ```
 BOND="bond0:eth0,eth1 bond1:eth2,eth3"
 ```
+Optionally, the hardware address for the interface can be specified (this can be useful for DHCP, note the format):
+```
+BOND="bond0:eth0,eth1:aa-bb-cc-dd-ee-ff"
+```
 With the following Line you can define the [Bonding Driver Options](https://wiki.linuxfoundation.org/networking/bonding#bonding_driver_options)
 For example use:
 ```

--- a/etc/initramfs-tools/scripts/local-top/bond
+++ b/etc/initramfs-tools/scripts/local-top/bond
@@ -25,11 +25,15 @@ modprobe bonding $BOND_MODE
 for BOND_IFACE in ${BOND:-*}; do
     BOND_DEVICE=$(echo $BOND_IFACE | cut -d":" -f1)
     BOND_SLAVES=$(echo $BOND_IFACE | cut -d":" -f2 | sed "s/,/ /g")
+    BOND_ADDR=$(echo $BOND_IFACE | cut -d":" -f3 | tr - :)
     log_begin_msg "Bringing up $BOND_DEVICE"
     ip link add $BOND_DEVICE type bond
     for BOND_SLAVE in $BOND_SLAVES; do
         ip link set $BOND_SLAVE master $BOND_DEVICE
     done
+    if [ -n "$BOND_ADDR" ]; then
+        ip link set $BOND_DEVICE address $BOND_ADDR
+    fi
     log_end_msg
 done
 


### PR DESCRIPTION
As discussed in #8, hardware address is written in the `aa-bb-cc-dd-ee-ff` format to allow expanding `:` separated configurations in the future.

Closes #8.
