### PR TITLE
read drop-in configs

### DIFF
--- a/etc/initramfs-tools/hooks/bond
+++ b/etc/initramfs-tools/hooks/bond
@@ -15,6 +15,6 @@ esac
 . /usr/share/initramfs-tools/hook-functions
 # Begin real processing below this line
 
-if grep -q ^BOND= /etc/initramfs-tools/initramfs.conf; then
+if grep -rq ^BOND= /etc/initramfs-tools/initramfs.conf /etc/initramfs-tools/conf.d; then
     manual_add_modules bonding
 fi

--- a/etc/initramfs-tools/hooks/vlan
+++ b/etc/initramfs-tools/hooks/vlan
@@ -15,6 +15,6 @@ esac
 . /usr/share/initramfs-tools/hook-functions
 # Begin real processing below this line
 
-if grep -q ^VLAN= /etc/initramfs-tools/initramfs.conf; then
+if grep -rq ^VLAN= /etc/initramfs-tools/initramfs.conf /etc/initramfs-tools/conf.d; then
     manual_add_modules 8021q
 fi

--- a/etc/initramfs-tools/scripts/local-bottom/bond
+++ b/etc/initramfs-tools/scripts/local-bottom/bond
@@ -25,6 +25,8 @@ for BOND_IFACE in ${BOND:-*}; do
     BOND_DEVICE=$(echo $BOND_IFACE | cut -d":" -f1)
     log_begin_msg "Bringing down $BOND_DEVICE"
     ip link delete $BOND_DEVICE
+    rm /run/net-$BOND_DEVICE.conf \
+       /run/netplan/$BOND_DEVICE.yaml
     log_end_msg
 done
 

--- a/etc/initramfs-tools/scripts/local-bottom/bond
+++ b/etc/initramfs-tools/scripts/local-bottom/bond
@@ -15,6 +15,7 @@ esac
 
 . /scripts/functions
 . /conf/initramfs.conf
+. /conf/conf.d/*.conf
 
 if [ -z "$BOND" ]; then
     exit 0

--- a/etc/initramfs-tools/scripts/local-bottom/vlan
+++ b/etc/initramfs-tools/scripts/local-bottom/vlan
@@ -15,6 +15,7 @@ esac
 
 . /scripts/functions
 . /conf/initramfs.conf
+. /conf/conf.d/*.conf
 
 if [ -z "$VLAN" ]; then
     exit 0

--- a/etc/initramfs-tools/scripts/local-top/bond
+++ b/etc/initramfs-tools/scripts/local-top/bond
@@ -15,6 +15,7 @@ esac
 
 . /scripts/functions
 . /conf/initramfs.conf
+. /conf/conf.d/*.conf
 
 if [ -z "$BOND" ]; then
     exit 0

--- a/etc/initramfs-tools/scripts/local-top/vlan
+++ b/etc/initramfs-tools/scripts/local-top/vlan
@@ -15,6 +15,7 @@ esac
 
 . /scripts/functions
 . /conf/initramfs.conf
+. /conf/conf.d/*.conf
 
 if [ -z "$VLAN" ]; then
     exit 0


### PR DESCRIPTION
Hi!

What do you think about this?
I always prefer drop-in configs and leave intact those which came from the package.

`man initramfs.conf`
_Configuration  options can be broken out into configuration snippets and placed in individual files in the /etc/initramfs-tools/conf.d directory.  Files in this directory are always read after the main configuration file, so you can override the settings in the main config file without editing it directly._


Regards,