### PR TITLE
bond fix for Ubuntu 22.04

### DIFF
--- a/etc/initramfs-tools/scripts/init-bottom/bond
+++ b/etc/initramfs-tools/scripts/init-bottom/bond
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-PREREQ=""
+PREREQ="cloud-initramfs-dyn-netconf"
 
 prereqs() {
     echo "$PREREQ"


### PR DESCRIPTION
Dear @stcz,
I'm really curious about your opinion with this.

On Ubuntu 22.04 it seems like the script execution order changed  so I had to delete the bond interface in a later step.
The bond interface previously went down (in `local-bottom` by your script) before `/scripts/init-bottom/cloud-initramfs-dyn-netconf` could be executed. https://packages.ubuntu.com/jammy/cloud-initramfs-dyn-netconf
This init-bottom script calls `configure_networking` from `scripts/functions` then it wants to bring up the bond interface again after we've deleted it already. But ofc it can't without your helper scripts so it hangs for 180secs before it would continue.

This fix should work even after someone removes the cloud-initramfs-dyn-netconf package.

Have you experienced anything similar on Debian?
I'll give it a try on Ubuntu 20.04 too but imho this change should work there also because I just remove the bond interface later.

![bond_initramfs](https://user-images.githubusercontent.com/51884166/178082189-c194bc3d-cef0-420e-8039-a37473d55907.png)

Thanks and regards,