### PR TITLE
Bringing down bonding-slaves interface after destroying bond master

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ With this initramfs scripts it is possible to add a bond or vlan device to your 
 
 You can add this hooks to your initramfs-tools to get support for bond interfaces or vlan interfaces during boot. You can configure the hooks in your /etc/initramfs-tools/initramfs.conf. Tested successful under debian 10. It should also work on other debian based Distros like ubuntu.
 
-The scripts should leave a empty networkconfiguration for the operating system.
+The scripts should leave an empty network configuration for the operating system.
 
 # Requiments
 The package `iproute2` for bonding support.

--- a/etc/initramfs-tools/scripts/init-bottom/bond
+++ b/etc/initramfs-tools/scripts/init-bottom/bond
@@ -23,11 +23,18 @@ fi
 
 for BOND_IFACE in ${BOND:-*}; do
     BOND_DEVICE=$(echo $BOND_IFACE | cut -d":" -f1)
+    BOND_SLAVES=$(echo $BOND_IFACE | cut -d":" -f2 | sed "s/,/ /g")
     log_begin_msg "Bringing down $BOND_DEVICE"
     ip link delete $BOND_DEVICE
     rm /run/net-$BOND_DEVICE.conf \
        /run/netplan/$BOND_DEVICE.yaml
     log_end_msg
+
+    for BOND_SLAVE in $BOND_SLAVES; do
+        log_begin_msg "Bringing down $BOND_SLAVE"
+            ip link    set   dev "${BOND_SLAVE}" down
+        log_end_msg
+    done
 done
 
 exit 0


### PR DESCRIPTION
Added a small patch which should bring down ex-slaves of the bond master. Sometimes the issue happens at Ubuntu 22.04.1 in between of the switch from initram into the OS when the OS cannot setup bond device (with `ipupdown` network configuration).